### PR TITLE
fix: Redirect to report with proper filter

### DIFF
--- a/non_profit/non_profit/doctype/member/member.js
+++ b/non_profit/non_profit/doctype/member/member.js
@@ -21,18 +21,15 @@ frappe.ui.form.on('Member', {
 
 			// custom buttons
 			frm.add_custom_button(__('Accounting Ledger'), function() {
-				if(frm.doc.customer){
-					frappe.set_route('query-report', 'General Ledger',
-							 {party_type:'Customer', party:frm.doc.customer});
-				}
-				else{
-					frappe.set_route('query-report', 'General Ledger',
-							 {party_type:'Member', party:frm.doc.name});
+				if (frm.doc.customer) {
+					frappe.set_route('query-report', 'General Ledger', {party_type: 'Customer', party: frm.doc.customer});
+				} else {
+					frappe.set_route('query-report', 'General Ledger', {party_type: 'Member', party: frm.doc.name});
 				}
 			});
 
 			frm.add_custom_button(__('Accounts Receivable'), function() {
-				frappe.set_route('query-report', 'Accounts Receivable', {customer:frm.doc.customer});
+				frappe.set_route('query-report', 'Accounts Receivable', {customer: frm.doc.customer});
 			});
 
 			if (!frm.doc.customer) {

--- a/non_profit/non_profit/doctype/member/member.js
+++ b/non_profit/non_profit/doctype/member/member.js
@@ -21,12 +21,18 @@ frappe.ui.form.on('Member', {
 
 			// custom buttons
 			frm.add_custom_button(__('Accounting Ledger'), function() {
-				frappe.set_route('query-report', 'General Ledger',
-					{party_type:'Member', party:frm.doc.name});
+				if(frm.doc.customer){
+					frappe.set_route('query-report', 'General Ledger',
+							 {party_type:'Customer', party:frm.doc.customer});
+				}
+				else{
+					frappe.set_route('query-report', 'General Ledger',
+							 {party_type:'Member', party:frm.doc.name});
+				}
 			});
 
 			frm.add_custom_button(__('Accounts Receivable'), function() {
-				frappe.set_route('query-report', 'Accounts Receivable', {member:frm.doc.name});
+				frappe.set_route('query-report', 'Accounts Receivable', {customer:frm.doc.customer});
 			});
 
 			if (!frm.doc.customer) {


### PR DESCRIPTION
**`Version`**
ERPNext: v14.0.0-develop
Frappe Framework: v14.x.x-develop

- Please also update version 13

**Before:**

- In Member doctype, when clicking Accounting Ledger then redirect to General Ledger report but the filter does not work with a customer. and when clicking Accounts Receivable then redirects to the Accounts Receivable report but one issue is like the member filter has not in the report. 


https://user-images.githubusercontent.com/99652762/176614354-67ae2059-21d5-4ba9-ab7c-af11a4678423.mp4

**After:**

- After developing, if the customer has in member form and clicks Accounting Ledger then will redirect to General Ledger report with customer filter.
```
if(frm.doc.customer){
	frappe.set_route('query-report', 'General Ledger',
				{party_type:'Customer', party:frm.doc.customer});
}
else{
	frappe.set_route('query-report', 'General Ledger',
				{party_type:'Member', party:frm.doc.name});
}
```

- And Also set conditions for the Accounts Receivable report
```
frappe.set_route('query-report', 'Accounts Receivable', {customer:frm.doc.customer});
```


https://user-images.githubusercontent.com/99652762/176615788-5eae6fbc-4743-47d8-85c3-40103bddfad3.mp4


Thank You!