### PR TITLE
Deleting forced billing cycle based on not existing setting

### DIFF
--- a/non_profit/non_profit/doctype/membership/membership.py
+++ b/non_profit/non_profit/doctype/membership/membership.py
@@ -54,11 +54,6 @@ class Membership(Document):
 
 			self.from_date = add_days(last_membership.to_date, 1)
 
-		if frappe.db.get_single_value("Non Profit Settings", "billing_cycle") == "Yearly":
-			self.to_date = add_years(self.from_date, 1)
-		else:
-			self.to_date = add_months(self.from_date, 1)
-
 	def on_payment_authorized(self, status_changed_to=None):
 		if status_changed_to not in ("Completed", "Authorized"):
 			return


### PR DESCRIPTION
There is no setting called "billing cycle". Also, it generally makes no sense to force a monthly membership. This should be left to the organisation to fill in.

#22 